### PR TITLE
Allow "_" in fullname

### DIFF
--- a/lib/betagouvbot/account_request.rb
+++ b/lib/betagouvbot/account_request.rb
@@ -70,7 +70,7 @@ module BetaGouvBot
 
     def validate_fullname
       fullname &&
-        fullname == fullname[/\A[a-z\.\-.]+\z/] ||
+        fullname == fullname[/\A[a-z\.\-\_.]+\z/] ||
         errors.add(:base, 'Le format du nom doit être prenom.nom')
     end
 


### PR DESCRIPTION
D’après https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-un-membre-à-la-communauté-betagouv:

>  Les parties prenom et nom sont en minuscules et sans accents. Les espaces des noms propres sont remplacés par _ et les tirets restent.

Mais la regexp de validation ne permet pas les "_", ce qui bloque la création de `/compte` :shrug: