### PR TITLE
Netlify + Betagouv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 > Outil d'automatisation des tâches administratives récurrentes et chronophages de l'[incubateur de services numériques](https://beta.gouv.fr)
 
-This is an automated assistant to administrative tasks related to sgmap/beta.gouv.fr
+This is an automated assistant to administrative tasks related to betagouv/beta.gouv.fr
 
 ## Getting started
 
 Requirements and install commands are available in [circle.yml](circle.yml).
 
 You can run the service locally with `bundle exec thin -p 8000 start` (cf. [the last command in Dockerfile](Dockerfile)).
-

--- a/betagouvbot.gemspec
+++ b/betagouvbot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['betagouvbot@beta.gouv.fr']
 
   spec.summary       = 'Automated assistant for beta.gouv.fr administrative tasks.'
-  spec.homepage      = 'https://github.com/sgmap/betagouvbot'
+  spec.homepage      = 'https://github.com/betagouv/betagouvbot'
   spec.license       = 'AGPL-3.0'
 
   spec.files         = Dir['{lib,data}/**/*', 'README*', 'Rakefile', 'config.ru']

--- a/data/mail_1day.md
+++ b/data/mail_1day.md
@@ -3,9 +3,11 @@ Bonjour {{author.fullname}} !
 
 D'après [nos informations](https://beta.gouv.fr/communaute/), ton contrat actuel arrive à expiration demain.
 
-Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant ton renouvellement contractuel : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin](https://github.com/sgmap/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md).
+Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant ton renouvellement contractuel : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md).
 
-Si c'est bien un "au revoir", c'est le moment de t'assurer que tu as bien coché tous les éléments de la [checklist de départ](https://github.com/sgmap/beta.gouv.fr/wiki/Au-revoir).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
+
+Si c'est bien un "au revoir", c'est le moment de t'assurer que tu as bien coché tous les éléments de la [checklist de départ](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir).
 
 On espère que tu as passé un moment positif avec nous !
 

--- a/data/mail_2w.md
+++ b/data/mail_2w.md
@@ -3,9 +3,11 @@ Bonjour {{author.fullname}} !
 
 D'après [nos informations](https://beta.gouv.fr/communaute/), ton contrat actuel arrive à expiration le {{author.end | format DD/MM/YYYY}}.
 
-Si c'est bien normal, assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/sgmap/beta.gouv.fr/wiki/Au-revoir) en partant.
+Si c'est bien normal, assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
 
-Si ton contrat a été prolongé et que tes nouvelles dates sont certaines, [mets-les à jour](https://github.com/sgmap/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) en deux minutes tout de suite !
+Si ton contrat a été prolongé et que tes nouvelles dates sont certaines, [mets-les à jour](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) en deux minutes tout de suite !
+
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/data/mail_3w.md
+++ b/data/mail_3w.md
@@ -3,9 +3,11 @@ Bonjour {{author.fullname}} !
 
 D'après [nos informations](https://beta.gouv.fr/communaute/), ton contrat actuel arrive à expiration le {{author.end | format DD/MM/YYYY}}.
 
-Si c'est bien normal, assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/sgmap/beta.gouv.fr/wiki/Au-revoir) en partant.
+Si c'est bien normal, assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
 
-Si ton contrat a été prolongé et que tes nouvelles dates sont certaines, [mets-les à jour en deux minutes](https://github.com/sgmap/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
+Si ton contrat a été prolongé et que tes nouvelles dates sont certaines, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
+
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/data/mail_after.md
+++ b/data/mail_after.md
@@ -1,12 +1,12 @@
 Contrat expiré
 Bonjour les loulous,
 
-{{author.fullname}} est apparemment parti·e hier. Il faut vérifier, soit que son contrat a été renouvelé et dans ce cas [mettre à jour sa nouvelle date de fin](https://github.com/sgmap/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md), soit que c'est bien un "au revoir".
+{{author.fullname}} est apparemment parti·e hier. Il faut vérifier, soit que son contrat a été renouvelé et dans ce cas [mettre à jour sa nouvelle date de fin](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md), soit que c'est bien un "au revoir".
 
 Si c'est un départ effectif, il faut s'assurer qu'elle ou il est bien :
 
-- Dans la team [alumni](https://github.com/orgs/sgmap/teams/alumni) sur GitHub.
-- Sans droit d'écriture sur des [dépôts](https://github.com/orgs/sgmap/people) sur GitHub.
+- Dans la team [alumni](https://github.com/orgs/betagouv/teams/alumni) sur GitHub.
+- Sans droit d'écriture sur des [dépôts](https://github.com/orgs/betagouv/people) sur GitHub.
 - Sans droit d'écriture sur l'agenda public.
 - Sans droit de délégation sur le [manager OVH](https://www.ovh.com/manager/web/#/configuration/email_domain/beta.gouv.fr?tab=EMAILS).
 - Organisé son pot de départ ☺

--- a/data/mail_compte.md
+++ b/data/mail_compte.md
@@ -6,7 +6,7 @@ On vient de créer ou mettre à jour ton adresse mail: {{author.id}}@beta.gouv.f
 {% if redirect %}
 Les mails envoyés à cette adresse seront redirigés vers ton adresse {{redirect}}.
 {% else %}
-Tu pourras consulter ces mails directement par interface Web ou IMAP, plus de détails sur [le wiki](https://github.com/sgmap/beta.gouv.fr/wiki/Mail).
+Tu pourras consulter ces mails directement par interface Web ou IMAP, plus de détails sur [le wiki](https://github.com/betagouv/beta.gouv.fr/wiki/Mail).
 {% endif %}
 
 Fais-en bon usage. :)

--- a/spec/betagouvbot/github_request_spec.rb
+++ b/spec/betagouvbot/github_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BetaGouvBot::GithubRequest do
   let(:ted)         { { id: 'ted', fullname: 'Ted', end: tomorrow.iso8601 } }
   let(:members)     { [bob, ann, ted] }
 
-  it 'ensures all active members are invited to Github org BETAGOUV' do
+  it 'ensures all active members are invited to Github org BetaGouv' do
     is_expected.to have(1).items.and include(
       be_a_kind_of(BetaGouvBot::GithubOrgAction)
         .and(have_attributes(user: 'bob-gh', org: 'betagouv', team: '2348627'))

--- a/spec/betagouvbot/github_request_spec.rb
+++ b/spec/betagouvbot/github_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BetaGouvBot::GithubRequest do
   let(:ted)         { { id: 'ted', fullname: 'Ted', end: tomorrow.iso8601 } }
   let(:members)     { [bob, ann, ted] }
 
-  it 'ensures all active members are invited to Github org SGMAP' do
+  it 'ensures all active members are invited to Github org BETAGOUV' do
     is_expected.to have(1).items.and include(
       be_a_kind_of(BetaGouvBot::GithubOrgAction)
         .and(have_attributes(user: 'bob-gh', org: 'betagouv', team: '2348627'))


### PR DESCRIPTION
Cette PR fait deux choses :

- Remplace sgmap par betagouv pour l'entrée sur Github
- Ajoute un lien vers Netlify CMS sur les fiches de relance des mails

Il reste un sgmap, l'adresse sgmap@beta.gouv.fr .