### PR TITLE
Corrige le status badge CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://circleci.com/gh/sgmap/betaGouvBot.svg?style=shield)](https://circleci.com/gh/sgmap/betaGouvBot/tree/master)
+[![CircleCI](https://circleci.com/gh/betagouv/betaGouvBot.svg?style=svg)](https://circleci.com/gh/betagouv/betaGouvBot)
 
 # BetaGouvBot
 


### PR DESCRIPTION
Met à jour le badge CircleCI en haut de la page d'accueil.
> Corrige le lien cassé.
