### PR TITLE
Met à jour les termes des mails de rappel

### DIFF
--- a/data/mail_1day.md
+++ b/data/mail_1day.md
@@ -1,9 +1,9 @@
-⏰ Dernier jour pour faire le point sur ton contrat
+⏰ Dernier jour pour faire le point sur ta mission
 Bonjour {{author.fullname}} !
 
-D'après [nos informations](https://beta.gouv.fr/communaute/), c'est demain que ton contrat arrive à expiration ou doit être renouvelé.
+D'après [nos informations](https://beta.gouv.fr/communaute/), c'est demain qu'on devait statuer sur ta mission à beta, en particulier si tu restes parmi nous ou pas. Sans action de ta part, on va donc considérer que c'est ta date de départ.
 
-Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant ton renouvellement contractuel : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md). C'est possible que ces modifications ne soient pas publiées à temps, et que tu reçoives des messages de désabonnement à la liste de diffusion par exemple; ce n'est pas très grave, dès qu'elles seront publiées on te réabonnera à nouveau, etc.
+Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant la suite de ta mission : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin (ou de renouvellement)](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md). C'est possible que ces modifications ne soient pas publiées à temps, et que tu reçoives des messages de désabonnement à la liste de diffusion par exemple; ce n'est pas très grave, dès qu'elles seront publiées on te réabonnera à nouveau, etc.
 
 Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 

--- a/data/mail_1day.md
+++ b/data/mail_1day.md
@@ -3,7 +3,7 @@ Bonjour {{author.fullname}} !
 
 D'après [nos informations](https://beta.gouv.fr/communaute/), c'est demain qu'on devait statuer sur ta mission à beta, en particulier si tu restes parmi nous ou pas. Sans action de ta part, on va donc considérer que c'est ta date de départ.
 
-Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant la suite de ta mission : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin (ou de renouvellement)](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md). C'est possible que ces modifications ne soient pas publiées à temps, et que tu reçoives des messages de désabonnement à la liste de diffusion par exemple; ce n'est pas très grave, dès qu'elles seront publiées on te réabonnera à nouveau, etc.
+Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant la suite de ta mission : si c'est le cas, on s'en réjouit et tu peux dès maintenant [mettre à jour ta nouvelle date de fin (ou de renouvellement)](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md). C'est possible que ces modifications ne soient pas publiées à temps, et que tu reçoives des messages de désabonnement à la liste de diffusion par exemple; ce n'est pas très grave, dès qu'elles seront publiées on te réabonnera à nouveau, etc.
 
 Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 

--- a/data/mail_1day.md
+++ b/data/mail_1day.md
@@ -1,9 +1,9 @@
-⏰ Fin de contrat prévue pour demain
+⏰ Dernier jour pour faire le point sur ton contrat
 Bonjour {{author.fullname}} !
 
-D'après [nos informations](https://beta.gouv.fr/communaute/), ton contrat actuel arrive à expiration demain.
+D'après [nos informations](https://beta.gouv.fr/communaute/), c'est demain que ton contrat arrive à expiration ou doit être renouvelé.
 
-Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant ton renouvellement contractuel : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md).
+Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant ton renouvellement contractuel : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md). C'est possible que ces modifications ne soient pas publiées à temps, et que tu reçoives des messages de désabonnement à la liste de diffusion par exemple; ce n'est pas très grave, dès qu'elles seront publiées on te réabonnera à nouveau, etc.
 
 Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}).
 

--- a/data/mail_1day.md
+++ b/data/mail_1day.md
@@ -5,7 +5,7 @@ D'après [nos informations](https://beta.gouv.fr/communaute/), c'est demain que 
 
 Peut-être que tu as oublié, ou remis à la dernière minute, ou que tu n'avais pas encore tous les éléments concernant ton renouvellement contractuel : si c'est le cas, on en serait plutôt ravis et tu peux dès maintenant [mettre à jour ta nouvelle date de fin](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md). C'est possible que ces modifications ne soient pas publiées à temps, et que tu reçoives des messages de désabonnement à la liste de diffusion par exemple; ce n'est pas très grave, dès qu'elles seront publiées on te réabonnera à nouveau, etc.
 
-Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 
 Si c'est bien un "au revoir", c'est le moment de t'assurer que tu as bien coché tous les éléments de la [checklist de départ](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir).
 

--- a/data/mail_2w.md
+++ b/data/mail_2w.md
@@ -1,4 +1,4 @@
-🗓 Plus que 2 semaines pour faire le point sur ton contrat
+⏲ Plus que 2 semaines pour faire le point sur ton contrat
 Bonjour {{author.fullname}} !
 
 D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} que ton contrat doit être renouvelé ou bien arriver à échéance.

--- a/data/mail_2w.md
+++ b/data/mail_2w.md
@@ -7,7 +7,7 @@ Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance
 
 Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
-Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/data/mail_2w.md
+++ b/data/mail_2w.md
@@ -1,13 +1,13 @@
-⏲ Fin de contrat prévue pour dans 2 semaines
+🗓 Plus que 2 semaines pour faire le point sur ton contrat
 Bonjour {{author.fullname}} !
 
-D'après [nos informations](https://beta.gouv.fr/communaute/), ton contrat actuel arrive à expiration le {{author.end | format DD/MM/YYYY}}.
+D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} que ton contrat doit être renouvelé ou bien arriver à échéance.
 
-Si c'est bien normal, assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
+Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
 
-Si ton contrat a été prolongé et que tes nouvelles dates sont certaines, [mets-les à jour](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) en deux minutes tout de suite !
+Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
-Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/data/mail_2w.md
+++ b/data/mail_2w.md
@@ -1,11 +1,11 @@
-⏲ Plus que 2 semaines pour faire le point sur ton contrat
+⏲ Plus que 2 semaines pour faire le point sur ta mission
 Bonjour {{author.fullname}} !
 
-D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} que ton contrat doit être renouvelé ou bien arriver à échéance.
+D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} qu'on avait prévu de faire le point sur ta mission à beta, en particulier si tu restes parmi nous ou pas.
 
 Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
 
-Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
+Si ta mission se prolonge et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
 Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 

--- a/data/mail_2w.md
+++ b/data/mail_2w.md
@@ -7,7 +7,7 @@ Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance
 
 Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
-Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/data/mail_3w.md
+++ b/data/mail_3w.md
@@ -7,7 +7,7 @@ Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance
 
 Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
-Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/data/mail_3w.md
+++ b/data/mail_3w.md
@@ -1,11 +1,11 @@
-🗓 Encore 3 semaines pour faire le point sur ton contrat
+🗓 Encore 3 semaines pour faire le point sur ta mission
 Bonjour {{author.fullname}} !
 
-D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} que ton contrat doit être renouvelé ou bien arriver à échéance.
+D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} qu'on avait prévu de faire le point sur ta mission à beta, en particulier si tu restes parmi nous ou pas.
 
 Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
 
-Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
+Si ta mission se prolonge et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
 Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 

--- a/data/mail_3w.md
+++ b/data/mail_3w.md
@@ -1,11 +1,11 @@
-🗓 Fin de contrat prévue pour dans 3 semaines
+🗓 Encore 3 semaines pour faire le point sur ton contrat
 Bonjour {{author.fullname}} !
 
-D'après [nos informations](https://beta.gouv.fr/communaute/), ton contrat actuel arrive à expiration le {{author.end | format DD/MM/YYYY}}.
+D'après [nos informations](https://beta.gouv.fr/communaute/), c'est le {{author.end | format DD/MM/YYYY}} que ton contrat doit être renouvelé ou bien arriver à échéance.
 
-Si c'est bien normal, assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
+Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance dès maintenant de [ce qu'il te faudra faire](https://github.com/betagouv/beta.gouv.fr/wiki/Au-revoir) en partant.
 
-Si ton contrat a été prolongé et que tes nouvelles dates sont certaines, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
+Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
 Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/).
 

--- a/data/mail_3w.md
+++ b/data/mail_3w.md
@@ -7,7 +7,7 @@ Si tu nous quittes bien à cette date (snif), assure-toi de prendre connaissance
 
 Si ton contrat a été prolongé et que tes nouvelles dates sont connues, [mets-les à jour en deux minutes](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{author.id}}.md) tout de suite !
 
-Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
+Tu n'es pas à l'aise avec Github ? Tu peux le faire [directement à travers notre interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/{{author.id}}) en suivant [ce petit guide](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA).
 
 Si quelque chose n'est pas clair, réponds à cet email ou ouvre une conversation dans [#administration](https://startups-detat.slack.com/archives/incubateur-secretaria) sur Slack.
 

--- a/spec/betagouvbot/notification_request_spec.rb
+++ b/spec/betagouvbot/notification_request_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe BetaGouvBot::NotificationRequest do
       let(:authors) { [id: 'ann', fullname: 'Ann', end: (Date.today + 21).iso8601] }
 
       it 'sends an email directly to the author' do
+        three_weeks = '🗓 Encore 3 semaines pour faire le point sur ton contrat'
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
-          .and(have_attributes(subject: '🗓 Encore 3 semaines pour faire le point sur ton contrat'))
+          .and(have_attributes(subject: three_weeks))
           .and(have_attributes(recipients: ['email' => 'ann@beta.gouv.fr']))
       end
     end
@@ -25,8 +26,9 @@ RSpec.describe BetaGouvBot::NotificationRequest do
           { 'email' => 'ann@beta.gouv.fr' },
           { 'email' => 'contact@beta.gouv.fr' }
         ]
+        two_weeks = '⏲ Plus que 2 semaines pour faire le point sur ton contrat'
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
-          .and(have_attributes(subject: '⏲ Plus que 2 semaines pour faire le point sur ton contrat'))
+          .and(have_attributes(subject: two_weeks))
           .and(have_attributes(recipients: recipients))
       end
     end

--- a/spec/betagouvbot/notification_request_spec.rb
+++ b/spec/betagouvbot/notification_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BetaGouvBot::NotificationRequest do
   describe 'selecting recipients of emails' do
     context 'when a member has an end date in three weeks' do
       let(:authors) { [id: 'ann', fullname: 'Ann', end: (Date.today + 21).iso8601] }
-      let(:three_weeks) { '🗓 Encore 3 semaines pour faire le point sur ton contrat' }
+      let(:three_weeks) { '🗓 Encore 3 semaines pour faire le point sur ta mission' }
 
       it 'sends an email directly to the author' do
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
@@ -20,7 +20,7 @@ RSpec.describe BetaGouvBot::NotificationRequest do
 
     context 'when a member has an end date in two weeks' do
       let(:authors) { [id: 'ann', fullname: 'Ann', end: (Date.today + 14).iso8601] }
-      let(:two_weeks) { '⏲ Plus que 2 semaines pour faire le point sur ton contrat' }
+      let(:two_weeks) { '⏲ Plus que 2 semaines pour faire le point sur ta mission' }
 
       it 'sends an email to the author and contact' do
         recipients = [

--- a/spec/betagouvbot/notification_request_spec.rb
+++ b/spec/betagouvbot/notification_request_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BetaGouvBot::NotificationRequest do
         recipients = [
           { 'email' => 'ann@beta.gouv.fr' },
           { 'email' => 'contact@beta.gouv.fr' }
-        ]        
+        ]
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
           .and(have_attributes(subject: two_weeks))
           .and(have_attributes(recipients: recipients))

--- a/spec/betagouvbot/notification_request_spec.rb
+++ b/spec/betagouvbot/notification_request_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe BetaGouvBot::NotificationRequest do
   describe 'selecting recipients of emails' do
     context 'when a member has an end date in three weeks' do
       let(:authors) { [id: 'ann', fullname: 'Ann', end: (Date.today + 21).iso8601] }
+      let(:three_weeks) { '🗓 Encore 3 semaines pour faire le point sur ton contrat' }
 
       it 'sends an email directly to the author' do
-        three_weeks = '🗓 Encore 3 semaines pour faire le point sur ton contrat'
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
           .and(have_attributes(subject: three_weeks))
           .and(have_attributes(recipients: ['email' => 'ann@beta.gouv.fr']))
@@ -20,13 +20,13 @@ RSpec.describe BetaGouvBot::NotificationRequest do
 
     context 'when a member has an end date in two weeks' do
       let(:authors) { [id: 'ann', fullname: 'Ann', end: (Date.today + 14).iso8601] }
+      let(:two_weeks) { '⏲ Plus que 2 semaines pour faire le point sur ton contrat' }
 
       it 'sends an email to the author and contact' do
         recipients = [
           { 'email' => 'ann@beta.gouv.fr' },
           { 'email' => 'contact@beta.gouv.fr' }
-        ]
-        two_weeks = '⏲ Plus que 2 semaines pour faire le point sur ton contrat'
+        ]        
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
           .and(have_attributes(subject: two_weeks))
           .and(have_attributes(recipients: recipients))

--- a/spec/betagouvbot/notification_request_spec.rb
+++ b/spec/betagouvbot/notification_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BetaGouvBot::NotificationRequest do
 
       it 'sends an email directly to the author' do
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
-          .and(have_attributes(subject: '🗓 Fin de contrat prévue pour dans 3 semaines'))
+          .and(have_attributes(subject: '🗓 Encore 3 semaines pour faire le point sur ton contrat'))
           .and(have_attributes(recipients: ['email' => 'ann@beta.gouv.fr']))
       end
     end
@@ -26,7 +26,7 @@ RSpec.describe BetaGouvBot::NotificationRequest do
           { 'email' => 'contact@beta.gouv.fr' }
         ]
         is_expected.to include be_a_kind_of(BetaGouvBot::MailAction)
-          .and(have_attributes(subject: '⏲ Fin de contrat prévue pour dans 2 semaines'))
+          .and(have_attributes(subject: '⏲ Plus que 2 semaines pour faire le point sur ton contrat'))
           .and(have_attributes(recipients: recipients))
       end
     end


### PR DESCRIPTION
Ne pas présenter les dates "de fin" comme ayant ce seul sens, mais plutôt comme une date à laquelle on convient de faire le point sur la situation de la personne.